### PR TITLE
fix: added dash and parenthesis characters to the validation

### DIFF
--- a/frontend/src/components/NewSettler/NewSettler.jsx
+++ b/frontend/src/components/NewSettler/NewSettler.jsx
@@ -79,14 +79,15 @@ const NewSettler = ({ isOpen, setIsOpen }) => {
                 onChange={handleChange}
                 type="tel"
                 name="phone"
+                maxLength="20"
                 placeholder="ТЕЛЕФОН*"
                 required
-                pattern="(\+)([\d]){5,16}$"
+                pattern="(\+)([\s\(\)\-\d]){10,20}$"
                 className={classNames(styles.input, {}, [errors.name ? styles.invalid : ''])}
               />
               <span className={styles.error}>
                 {errors.phone
-                  ? 'Номер должен начинаться со знака "+" иметь от 5 до 16 символов'
+                  ? 'Номер должен начинаться со знака "+" иметь от 10 до 15 символов'
                   : ''}
               </span>
             </div>


### PR DESCRIPTION
Исправлены ошибки согласно задачи из трелло [ссылка на задачу](https://trello.com/c/58fZrjbK/202-%D0%B2-%D0%BF%D0%BE%D0%BB%D0%B5-%D1%82%D0%B5%D0%BB%D0%B5%D1%84%D0%BE%D0%BD-%D0%BD%D0%B5%D0%BB%D1%8C%D0%B7%D1%8F-%D0%B2%D0%BD%D0%B5%D1%81%D1%82%D0%B8-%D1%81%D0%B8%D0%BC%D0%B2%D0%BE%D0%BB%D1%8B-%D1%81%D0%BA%D0%BE%D0%B1%D0%BE%D0%BA-%D0%B8-%D1%82%D0%B8%D1%80%D0%B5).
- изменил регулярное выражение для валидации, теперь оно принимает строку которая начинается только на "+" и может содержать символы "(", ")", "-", "пробел" и все цифры. Размер строки от 10 до 20 символов (до 20 потому что если сделать до 15 не влазят пробелы). Однако проходят валидацию и например такие номера: "+(((((((((((((((((((", "+-------------------" и т.д. Не знаю надо ли это править? конечная валидация все равно на бэке.
- подправил сообщение об ошибке согластно ТЗ,  [ссылкан на ТЗ](https://docs.google.com/document/d/1ROe9Jji3_vjHdW1s7Ii6pZGPmydfH9GvYKO3OJwmFfw/edit#heading=h.xr0okzvtolxo)