### PR TITLE
TD-234

### DIFF
--- a/frontend/src/components/ButtonCounter/ButtonCounter.jsx
+++ b/frontend/src/components/ButtonCounter/ButtonCounter.jsx
@@ -19,6 +19,7 @@ export const ButtonCounter = ({
       Отправить заново
       { counter !== 0 && (
         <>
+          {' '}
           00:
           {counter < 10 ? `0${counter}` : counter}
         </>

--- a/frontend/src/pages/RegisterPage/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage/RegisterPage.jsx
@@ -228,9 +228,9 @@ export function RegisterPage() {
                 <>
                   <p className={classNames(cls.text, {}, [cls.textSendData])}>
                     Мы отправили ссылку на указанную почту
+                    {' '}
                     {values.email}
-                    .Перейдите по ссылке из письма для подтверждения своего
-                    аккаунта.
+                    . Перейдите по ссылке из письма для подтверждения своего аккаунта.
                   </p>
                   <div className={cls.errorButtonWrapper}>
                     <Button


### PR DESCRIPTION
#### Task [TD-234](https://tessera-mosaic.atlassian.net/browse/TD-234) Registration pop-up: there is no space before and after email in pop up & in call down button

#### Fix: add spaces before variables

[TD-234]: https://tessera-mosaic.atlassian.net/browse/TD-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ