### PR TITLE
Td 211-bugfix-feat-social-media-icons 

### DIFF
--- a/frontend/src/components/InfoFooter/InfoFooter.module.scss
+++ b/frontend/src/components/InfoFooter/InfoFooter.module.scss
@@ -152,7 +152,6 @@
   .otherContainer {
     margin: 0;
     padding: 0 20px;
-    flex-direction: column;
     width: calc(100% - 40px);
     column-gap: 0;
   }

--- a/frontend/src/components/InfoFooter/InfoFooter.module.scss
+++ b/frontend/src/components/InfoFooter/InfoFooter.module.scss
@@ -154,9 +154,6 @@
     padding: 0 20px;
     flex-direction: column;
     width: calc(100% - 40px);
-    grid-template-areas: 
-      "logo linkList"
-      "navigation navigation";
     column-gap: 0;
   }
 


### PR DESCRIPTION
Было изменено расположение иконок соцсетей в футере. Были справа от лого, теперь внизу (под лого).